### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 > **Plot twist**: Instead of just telling people to RTFM, now you can actually give them an FM worth R-ing! Because the best response to "read the f*ing manual" is having a manual that's actually worth reading. 📚✨
 
+<a href="https://glama.ai/mcp/servers/44sgp6bmdc"><img width="380" height="200" src="https://glama.ai/mcp/servers/44sgp6bmdc/badge" alt="mcp-rtfm MCP server" /></a>
+
 ## 📚 Table of Contents
 
 - [Quick Start](#-quick-start)


### PR DESCRIPTION
This PR adds a badge for the mcp-rtfm server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/44sgp6bmdc"><img width="380" height="200" src="https://glama.ai/mcp/servers/44sgp6bmdc/badge" alt="mcp-rtfm MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.